### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Clonecontrib/Form/Contribution/Clone.php
+++ b/CRM/Clonecontrib/Form/Contribution/Clone.php
@@ -66,7 +66,7 @@ class CRM_Clonecontrib_Form_Contribution_Clone extends CRM_Core_Form {
       CRM_Core_Session::setStatus($message, E::ts('API Error'), 'error');
       return;
     }
-    $newContribution = CRM_Utils_Array::value(0, $contribution['values']);
+    $newContribution = $contribution['values'][0] ?? NULL;
     if (!$newContribution) {
       $message = E::ts('Unknown error; could not determine ID of cloned contribution.');
       CRM_Core_Session::setStatus($message, E::ts('Unknown error'), 'error');
@@ -74,15 +74,15 @@ class CRM_Clonecontrib_Form_Contribution_Clone extends CRM_Core_Form {
     }
 
     $message = E::ts('The new contribution has been created with an ID of %1. Edit it here as needed.', array(
-      1 => CRM_Utils_Array::value('id', $newContribution),
+      1 => $newContribution['id'] ?? NULL,
     ));
     CRM_Core_Session::setStatus($message, E::ts('Contribution cloned'), 'info');
 
     CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view/contribution', array(
       'reset' => '1',
       'action' => 'update',
-      'id' => CRM_Utils_Array::value('id', $newContribution),
-      'cid' => CRM_Utils_Array::value('contact_id', $newContribution),
+      'id' => $newContribution['id'] ?? NULL,
+      'cid' => $newContribution['contact_id'] ?? NULL,
       'context' => 'contribution',
     )));
 

--- a/CRM/Clonecontrib/Form/Settings.php
+++ b/CRM/Clonecontrib/Form/Settings.php
@@ -167,7 +167,7 @@ class CRM_Clonecontrib_Form_Settings extends CRM_Core_Form {
     // checkboxes need flipping because all values are '1' instead of the key.
     foreach ($values as $key => &$value) {
       $setting = CRM_Utils_Array::value($key, $settings, FALSE);
-      if ('CheckBox' == CRM_Utils_Array::value('html_type', $setting)) {
+      if ('CheckBox' == $setting['html_type'] ?? NULL) {
         $value = array_keys($value);
       }
     }
@@ -193,13 +193,13 @@ class CRM_Clonecontrib_Form_Settings extends CRM_Core_Form {
         'return' => array_keys($this->_settings),
         'sequential' => 1,
       ));
-      $ret = CRM_Utils_Array::value(0, $result['values']);
+      $ret = $result['values'][0] ?? NULL;
 
       // checkboxes need flipping because all values are '1' instead of the key.
       $settings = $this->_settings;
       foreach ($ret as $key => &$value) {
         $setting = CRM_Utils_Array::value($key, $settings, FALSE);
-        if ('CheckBox' == CRM_Utils_Array::value('html_type', $setting)) {
+        if ('CheckBox' == $setting['html_type'] ?? NULL) {
           $value = array_fill_keys(array_values($value), '1');
         }
       }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.