### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Clonecontrib/Form/Contribution/Clone.php
+++ b/CRM/Clonecontrib/Form/Contribution/Clone.php
@@ -59,7 +59,7 @@ class CRM_Clonecontrib_Form_Contribution_Clone extends CRM_Core_Form {
     try {
       $contribution = civicrm_api3('Contribution', 'clone', $contributionParams);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $message = E::ts('Could not clone; Contribution.clone API error: %1.', array(
         1 => $e->getMessage(),
       ));

--- a/api/v3/Contribution/Clone.php
+++ b/api/v3/Contribution/Clone.php
@@ -23,7 +23,7 @@ function _civicrm_api3_contribution_Clone_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_contribution_Clone($params) {
   // Get properties that should be excluded in cloning, per user config.


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.