### PR TITLE
hook_permission declaration deprecated

### DIFF
--- a/clonecontrib.php
+++ b/clonecontrib.php
@@ -12,7 +12,10 @@ use CRM_Clonecontrib_ExtensionUtil as E;
 function clonecontrib_civicrm_permission(&$permissions) {
   // name of extension or module
   $prefix = E::ts('CiviContribute') . ': ';
-  $permissions['clone contributions'] = $prefix . E::ts('clone contributions');
+  $permissions['clone contributions'] = [
+    'label' => $prefix . E::ts('clone contributions'),
+    'description' => '',
+  ];
 }
 
 /**


### PR DESCRIPTION
`[PHP User Deprecation] Permission 'clone contributions' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions`

